### PR TITLE
ellipsis seems doesn't work, remove body margin for narrow mobile view 

### DIFF
--- a/app/styles/base.css
+++ b/app/styles/base.css
@@ -13,6 +13,7 @@ body {
 
 .storyBoard {
   margin-top: 15px;
+  text-overflow: ellipsis;
 }
 
 .numSec {
@@ -133,7 +134,7 @@ a:hover {
 }
 
 @media screen and (max-width: 880px) {    
-    .numSec {
+  .numSec {
     visibility: hidden;
   }
 }
@@ -145,5 +146,20 @@ a:hover {
 }
 
 @media screen and (max-width: 500px) {
+  .nav-bar {
+    max-height: 0px;
+  }
+
+  .storyBoard {
+    height: 70px;
+  }
+
+  .storyBoard a{
+    text-overflow: ellipsis;
+  }
+
+  body {
+    margin: 0px;
+  }
 }
 


### PR DESCRIPTION
haven't taken a close look at the code yet, ellipsis seems doesn't work for me (maybe i put it in the wrong place), i see your point that text being cut off in narrow mobile view (<300ish px). I removed the body margin to make room for longer text (seems work fine for width >=300px), let me know where to put text-overflow
